### PR TITLE
Add basic tests for http_client and http_async_client

### DIFF
--- a/units/thacxx0001/README.md
+++ b/units/thacxx0001/README.md
@@ -1,0 +1,8 @@
+# http_aysnc_client - GET request #
+
+Summary: http_async_client - GET request
+
+Following tests are done:
+
+  * run kamailio with kamailio-thacxx0001.cfg and test if HTTP GET receives a 200
+

--- a/units/thacxx0001/http_server.py
+++ b/units/thacxx0001/http_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class HTTPHandler(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        self._set_response()
+
+def run(server_class=HTTPServer, handler_class=HTTPHandler, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+if __name__ == '__main__':
+    run()

--- a/units/thacxx0001/kamailio-thacxx0001.cfg
+++ b/units/thacxx0001/kamailio-thacxx0001.cfg
@@ -1,0 +1,30 @@
+#!KAMAILIO
+
+loadmodule "kex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "xlog.so"
+loadmodule "http_async_client.so"
+
+debug=2
+children=2
+
+request_route {
+	t_newtran();
+	# GET
+	http_async_query("http://127.0.0.1:8080/", "HTTP_REPLY");
+}
+
+route[HTTP_REPLY] {
+	if ($http_ok) {
+		xlog("L_INFO", "HTTP GET REPLY: $http_rs - Response: $http_rb\n");
+		sl_send_reply("200", "OK");
+		exit;
+	}
+	else {
+		xlog("L_ERR", "HTTP error: $http_err\n");
+	}
+}

--- a/units/thacxx0001/thacxx0001.sh
+++ b/units/thacxx0001/thacxx0001.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+. ../../etc/config
+. ../../libs/utils
+
+python3 http_server.py &
+
+echo "--- start kamailio -f ./kamailio-thacxx0001.cfg"
+${KAMBIN} -P ${KAMPID} -w ${KAMRUN} -Y ${KAMRUN} -f ./kamailio-thacxx0001.cfg -a no -ddd -E 2>&1 | tee /tmp/kamailio-thacxx0001.log &
+ret=$?
+sleep 1
+sipsak -s sip:test@127.0.0.1
+sleep 1
+kill_pidfile ${KAMPID}
+sleep 1
+killall python3
+sleep 1
+echo
+echo "--- grep output"
+echo
+grep "HTTP GET REPLY: 200" /tmp/kamailio-thacxx0001.log
+ret=$?
+if [ ! "$ret" -eq 0 ] ; then
+    exit 1
+fi
+exit 0

--- a/units/thacxx0002/README.md
+++ b/units/thacxx0002/README.md
@@ -1,0 +1,8 @@
+# http_aysnc_client - POST request #
+
+Summary: http_async_client - POST request
+
+Following tests are done:
+
+  * run kamailio with kamailio-thacxx0002.cfg and test if HTTP POST receives a 200
+

--- a/units/thacxx0002/http_server.py
+++ b/units/thacxx0002/http_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class HTTPHandler(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_POST(self):
+        self._set_response()
+
+def run(server_class=HTTPServer, handler_class=HTTPHandler, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+if __name__ == '__main__':
+    run()

--- a/units/thacxx0002/kamailio-thacxx0002.cfg
+++ b/units/thacxx0002/kamailio-thacxx0002.cfg
@@ -1,0 +1,34 @@
+#!KAMAILIO
+
+loadmodule "kex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "xlog.so"
+loadmodule "http_async_client.so"
+
+debug=2
+children=2
+
+request_route {
+	t_newtran();
+	$var(token) = "XYZ";
+	$http_req(body) = $_s({"city": "cagliari", "region": "sardinia"});
+	$http_req(hdr) = "Content-type: application/json";
+	$http_req(hdr) = "Authorization: Bearer " + $var(token);
+	# POST
+	http_async_query("http://127.0.0.1:8080/", "HTTP_REPLY");
+}
+
+route[HTTP_REPLY] {
+	if ($http_ok) {
+		xlog("L_INFO", "HTTP POST REPLY: $http_rs - Response: $http_rb\n");
+		sl_send_reply("200", "OK");
+		exit;
+	}
+	else {
+		xlog("L_ERR", "HTTP error: $http_err\n");
+	}
+}

--- a/units/thacxx0002/thacxx0002.sh
+++ b/units/thacxx0002/thacxx0002.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+. ../../etc/config
+. ../../libs/utils
+
+python3 http_server.py &
+
+echo "--- start kamailio -f ./kamailio-thacxx0002.cfg"
+${KAMBIN} -P ${KAMPID} -w ${KAMRUN} -Y ${KAMRUN} -f ./kamailio-thacxx0002.cfg -a no -ddd -E 2>&1 | tee /tmp/kamailio-thacxx0002.log &
+ret=$?
+sleep 1
+sipsak -s sip:test@127.0.0.1
+sleep 1
+kill_pidfile ${KAMPID}
+sleep 1
+killall python3
+sleep 1
+echo
+echo "--- grep output"
+echo
+grep "HTTP POST REPLY: 200" /tmp/kamailio-thacxx0002.log
+ret=$?
+if [ ! "$ret" -eq 0 ] ; then
+    exit 1
+fi
+exit 0

--- a/units/thacxx0003/README.md
+++ b/units/thacxx0003/README.md
@@ -1,0 +1,8 @@
+# http_aysnc_client - DELETE request #
+
+Summary: http_async_client - DELETE request
+
+Following tests are done:
+
+  * run kamailio with kamailio-thacxx0003.cfg and test if HTTP DELETE receives a 200
+

--- a/units/thacxx0003/http_server.py
+++ b/units/thacxx0003/http_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class HTTPHandler(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_DELETE(self):
+        self._set_response()
+
+def run(server_class=HTTPServer, handler_class=HTTPHandler, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+if __name__ == '__main__':
+    run()

--- a/units/thacxx0003/kamailio-thacxx0003.cfg
+++ b/units/thacxx0003/kamailio-thacxx0003.cfg
@@ -1,0 +1,34 @@
+#!KAMAILIO
+
+loadmodule "kex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "xlog.so"
+loadmodule "http_async_client.so"
+
+debug=2
+children=2
+
+request_route {
+	t_newtran();
+	$var(id) = "123";
+	$var(token) = "XYZ";
+	# DELETE
+	$http_req(method) = "DELETE";
+	$http_req(hdr) = "Authorization: Bearer " + $var(token);
+	http_async_query("http://127.0.0.1:8080/$var(id)", "HTTP_REPLY");
+}
+
+route[HTTP_REPLY] {
+	if ($http_ok) {
+		xlog("L_INFO", "HTTP DELETE REPLY: $http_rs - Response: $http_rb\n");
+		sl_send_reply("200", "OK");
+		exit;
+	}
+	else {
+		xlog("L_ERR", "HTTP error: $http_err\n");
+	}
+}

--- a/units/thacxx0003/thacxx0003.sh
+++ b/units/thacxx0003/thacxx0003.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+. ../../etc/config
+. ../../libs/utils
+
+python3 http_server.py &
+
+echo "--- start kamailio -f ./kamailio-thacxx0003.cfg"
+${KAMBIN} -P ${KAMPID} -w ${KAMRUN} -Y ${KAMRUN} -f ./kamailio-thacxx0003.cfg -a no -ddd -E 2>&1 | tee /tmp/kamailio-thacxx0003.log &
+ret=$?
+sleep 1
+sipsak -s sip:test@127.0.0.1
+sleep 1
+kill_pidfile ${KAMPID}
+sleep 1
+killall python3
+sleep 1
+echo
+echo "--- grep output"
+echo
+grep "HTTP DELETE REPLY: 200" /tmp/kamailio-thacxx0003.log
+ret=$?
+if [ ! "$ret" -eq 0 ] ; then
+    exit 1
+fi
+exit 0

--- a/units/thacxx0004/README.md
+++ b/units/thacxx0004/README.md
@@ -1,0 +1,8 @@
+# http_aysnc_client - POST request synchronous #
+
+Summary: http_async_client - POST request synchronous
+
+Following tests are done:
+
+  * run kamailio with kamailio-thacxx0004.cfg and test if synchronous HTTP POST receives a 200
+

--- a/units/thacxx0004/http_server.py
+++ b/units/thacxx0004/http_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class HTTPHandler(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_POST(self):
+        self._set_response()
+
+def run(server_class=HTTPServer, handler_class=HTTPHandler, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+if __name__ == '__main__':
+    run()

--- a/units/thacxx0004/kamailio-thacxx0004.cfg
+++ b/units/thacxx0004/kamailio-thacxx0004.cfg
@@ -1,0 +1,38 @@
+#!KAMAILIO
+
+loadmodule "kex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "xlog.so"
+loadmodule "http_async_client.so"
+
+debug=2
+children=2
+
+request_route {
+	$var(token) = "XYZ";
+	$http_req(body) = $_s({"city": "cagliari", "region": "sardinia"});
+	$http_req(hdr) = "Content-type: application/json";
+	$http_req(hdr) = "Authorization: Bearer " + $var(token);
+
+	$http_req(suspend) = 0;
+	# synchrounous POST
+	$var(result) = http_async_query("http://127.0.0.1:8080/", "HTTP_REPLY");
+
+	if ($var(result) == 1) {
+		sl_send_reply("200", "OK");
+		exit;
+	}
+}
+
+route[HTTP_REPLY] {
+	if ($http_ok) {
+		xlog("L_INFO", "HTTP POST REPLY: $http_rs - Response: $http_rb\n");
+	}
+	else {
+		xlog("L_ERR", "HTTP error: $http_err\n");
+	}
+}

--- a/units/thacxx0004/thacxx0004.sh
+++ b/units/thacxx0004/thacxx0004.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+. ../../etc/config
+. ../../libs/utils
+
+python3 http_server.py &
+
+echo "--- start kamailio -f ./kamailio-thacxx0004.cfg"
+${KAMBIN} -P ${KAMPID} -w ${KAMRUN} -Y ${KAMRUN} -f ./kamailio-thacxx0004.cfg -a no -ddd -E 2>&1 | tee /tmp/kamailio-thacxx0004.log &
+ret=$?
+sleep 1
+sipsak -s sip:test@127.0.0.1
+sleep 1
+kill_pidfile ${KAMPID}
+sleep 1
+killall python3
+sleep 1
+echo
+echo "--- grep output"
+echo
+grep "HTTP POST REPLY: 200" /tmp/kamailio-thacxx0004.log
+ret=$?
+if [ ! "$ret" -eq 0 ] ; then
+    exit 1
+fi
+exit 0

--- a/units/thttpc0001/README.md
+++ b/units/thttpc0001/README.md
@@ -1,0 +1,8 @@
+# http_client - GET request #
+
+Summary: http_client - GET request
+
+Following tests are done:
+
+  * run kamailio with kamailio-thttpc0001.cfg and test if HTTP GET receives a 200
+

--- a/units/thttpc0001/http_server.py
+++ b/units/thttpc0001/http_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class HTTPHandler(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        self._set_response()
+
+def run(server_class=HTTPServer, handler_class=HTTPHandler, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+if __name__ == '__main__':
+    run()

--- a/units/thttpc0001/kamailio-thttpc0001.cfg
+++ b/units/thttpc0001/kamailio-thttpc0001.cfg
@@ -1,0 +1,24 @@
+#!KAMAILIO
+
+loadmodule "kex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "xlog.so"
+loadmodule "http_client.so"
+
+debug=2
+children=2
+
+request_route {
+	$var(auth_token) = "XYZ";
+
+	# GET
+	$var(result) = http_client_query("http://127.0.0.1:8080", "", "Authorization: Bearer $var(auth_token)", "$var(response)");
+
+	xlog("L_INFO", "HTTP GET REPLY: $var(result) - Response: $var(response)\n");
+	sl_send_reply("200", "OK");
+	exit;
+}

--- a/units/thttpc0001/thttpc0001.sh
+++ b/units/thttpc0001/thttpc0001.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+. ../../etc/config
+. ../../libs/utils
+
+python3 http_server.py &
+
+echo "--- start kamailio -f ./kamailio-thttpc0001.cfg"
+${KAMBIN} -P ${KAMPID} -w ${KAMRUN} -Y ${KAMRUN} -f ./kamailio-thttpc0001.cfg -a no -ddd -E 2>&1 | tee /tmp/kamailio-thttpc0001.log &
+ret=$?
+sleep 1
+sipsak -s sip:test@127.0.0.1
+sleep 1
+kill_pidfile ${KAMPID}
+sleep 1
+killall python3
+sleep 1
+echo
+echo "--- grep output"
+echo
+grep "HTTP GET REPLY: 200" /tmp/kamailio-thttpc0001.log
+ret=$?
+if [ ! "$ret" -eq 0 ] ; then
+    exit 1
+fi
+exit 0

--- a/units/thttpc0002/README.md
+++ b/units/thttpc0002/README.md
@@ -1,0 +1,8 @@
+# http_client - POST request #
+
+Summary: http_client - POST request
+
+Following tests are done:
+
+  * run kamailio with kamailio-thttpc0002.cfg and test if HTTP POST receives a 200
+

--- a/units/thttpc0002/http_server.py
+++ b/units/thttpc0002/http_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class HTTPHandler(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_POST(self):
+        self._set_response()
+
+def run(server_class=HTTPServer, handler_class=HTTPHandler, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+if __name__ == '__main__':
+    run()

--- a/units/thttpc0002/kamailio-thttpc0002.cfg
+++ b/units/thttpc0002/kamailio-thttpc0002.cfg
@@ -1,0 +1,27 @@
+#!KAMAILIO
+
+loadmodule "kex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "xlog.so"
+loadmodule "http_client.so"
+
+debug=2
+children=2
+
+request_route {
+	$var(auth_token) = "XYZ";
+
+	# Some payload
+	$var(payload) = $_s({"city": "cagliari", "region": "sardinia"});
+
+	# POST
+	$var(result) = http_client_query("http://127.0.0.1:8080", "$var(payload)", "Content-type:application/json\r\nAuthorization: Bearer $var(auth_token)", "$var(response)");
+
+	xlog("L_INFO", "HTTP POST REPLY: $var(result) - Response: $var(response)\n");
+	sl_send_reply("200", "OK");
+	exit;
+}

--- a/units/thttpc0002/thttpc0002.sh
+++ b/units/thttpc0002/thttpc0002.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+. ../../etc/config
+. ../../libs/utils
+
+python3 http_server.py &
+
+echo "--- start kamailio -f ./kamailio-thttpc0002.cfg"
+${KAMBIN} -P ${KAMPID} -w ${KAMRUN} -Y ${KAMRUN} -f ./kamailio-thttpc0002.cfg -a no -ddd -E 2>&1 | tee /tmp/kamailio-thttpc0002.log &
+ret=$?
+sleep 1
+sipsak -s sip:test@127.0.0.1
+sleep 1
+kill_pidfile ${KAMPID}
+sleep 1
+killall python3
+sleep 1
+echo
+echo "--- grep output"
+echo
+grep "HTTP POST REPLY: 200" /tmp/kamailio-thttpc0002.log
+ret=$?
+if [ ! "$ret" -eq 0 ] ; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Tested with centos7 and kamailio `5.4` branch.
Adds some basic HTTP request scenarios for both `http_client` and `http_async_client`.