### PR TITLE
tests: fix thacxx0005/thacxx0006 SIPp scenarios and UAC port

### DIFF
--- a/units/thacxx0005/thacxx0005.sh
+++ b/units/thacxx0005/thacxx0005.sh
@@ -18,7 +18,7 @@ sleep 1
 
 NCALLS=20
 echo "-------------- starting sipp UAC -------------------------"
-sipp -sf uac.xml -m ${NCALLS} 127.0.0.1:5060
+sipp -sf uac.xml -p 5061 -m ${NCALLS} 127.0.0.1:5060
 
 kill_pidfile ${KAMPID}
 sleep 1

--- a/units/thacxx0005/uas.xml
+++ b/units/thacxx0005/uas.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <scenario name="Basic UAS scenario">
- <recv request="INVITE">
-  
- <!-- since SIPp complains about not used variable reference the trach var -->
- <Reference variables="trash"/>
+ <recv request="INVITE"/>
 
  <send retrans="500">
   <![CDATA[

--- a/units/thacxx0006/thacxx0006.sh
+++ b/units/thacxx0006/thacxx0006.sh
@@ -18,7 +18,7 @@ sleep 1
 
 NCALLS=20
 echo "-------------- starting sipp UAC -------------------------"
-sipp -sf uac.xml -m ${NCALLS} 127.0.0.1:5060
+sipp -sf uac.xml -p 5061 -m ${NCALLS} 127.0.0.1:5060
 
 kill_pidfile ${KAMPID}
 sleep 1

--- a/units/thacxx0006/uas.xml
+++ b/units/thacxx0006/uas.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <scenario name="Basic UAS scenario">
- <recv request="INVITE">
-  
- <!-- since SIPp complains about not used variable reference the trach var -->
- <Reference variables="trash"/>
+ <recv request="INVITE"/>
 
  <send retrans="500">
   <![CDATA[


### PR DESCRIPTION
- Close the unclosed <recv request="INVITE"> tag in the UAS scenario XML and drop the obsolete <Reference variables="trash"/> hack. Stricter SIPp builds reject the malformed XML and fail to start the UAS, causing the tests to fail.

- Pin the UAC to port 5061 to avoid an intermittent collision with Kamailio's UDP listener on 5060. Without the pin, sipp may bind to 5060 itself, intercept Kamailio's 200 OK, and stall the test until SIPp times out.