### PR TITLE
tests: tmodxx0001 - optional inclusion of rtp_media_server

### DIFF
--- a/units/tmodxx0001/kamailio-allmods.cfg
+++ b/units/tmodxx0001/kamailio-allmods.cfg
@@ -223,7 +223,9 @@ loadmodule "rls.so"
 loadmodule "rr.so"
 loadmodule "rtimer.so"
 loadmodule "rtjson.so"
-loadmodule "rtp_media_server"
+#!ifdef WITH_RTP_MEDIA_SERVER
+loadmodule "rtp_media_server.so"
+#!endif
 #!ifndef WITH_RTPPROXY
 loadmodule "rtpengine.so"
 #!else

--- a/units/tmodxx0001/tmodxx0001.sh
+++ b/units/tmodxx0001/tmodxx0001.sh
@@ -3,8 +3,13 @@
 . ../../etc/config
 . ../../libs/utils
 
-echo "--- start kamailio -f ./kamailio-allmods.cfg"
-${KAMBIN} -f ./kamailio-allmods.cfg -dd -E 2>&1 | tee /tmp/kamailio-allmods.log
+# enable defines for optional modules that are present in the build
+MODS_DIR=/usr/local/lib/kamailio/modules
+OPT_DEFINES=""
+[ -f "${MODS_DIR}/rtp_media_server.so" ] && OPT_DEFINES="${OPT_DEFINES} -A WITH_RTP_MEDIA_SERVER"
+
+echo "--- start kamailio -f ./kamailio-allmods.cfg ${OPT_DEFINES}"
+${KAMBIN} -f ./kamailio-allmods.cfg -dd -E ${OPT_DEFINES} 2>&1 | tee /tmp/kamailio-allmods.log
 echo
 echo "--- grep output"
 echo
@@ -13,8 +18,8 @@ ret=$?
 if [ ! "$ret" -eq 1 ] ; then
     exit 1
 fi
-echo "--- start kamailio -f ./kamailio-allmods.cfg -A WITH_IMS -A WITH_RTPPROXY"
-${KAMBIN} -f ./kamailio-allmods.cfg -dd -E  -A WITH_IMS -A WITH_RTPPROXY 2>&1 | tee /tmp/kamailio-allmods.log
+echo "--- start kamailio -f ./kamailio-allmods.cfg -A WITH_IMS -A WITH_RTPPROXY ${OPT_DEFINES}"
+${KAMBIN} -f ./kamailio-allmods.cfg -dd -E -A WITH_IMS -A WITH_RTPPROXY ${OPT_DEFINES} 2>&1 | tee /tmp/kamailio-allmods.log
 echo
 echo "--- grep output"
 echo


### PR DESCRIPTION
Wrap the rtp_media_server loadmodule in #!ifdef WITH_RTP_MEDIA_SERVER and have tmodxx0001.sh pass -A WITH_RTP_MEDIA_SERVER only when the module is present in the build. Lets the test run cleanly on builds that exclude rtp_media_server, without dropping coverage on builds that include it.

Also fixes the missing .so extension on the loadmodule line.